### PR TITLE
Bump alpine from 3.17.1 to 3.17.3 (#75)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.17.3
 
 LABEL maintainer "ferrari.marco@gmail.com"
 


### PR DESCRIPTION
Bumps alpine from 3.17.1 to 3.17.3.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-patch ...